### PR TITLE
Update hungarian bible references

### DIFF
--- a/cgi-bin/breviar-android.cfg
+++ b/cgi-bin/breviar-android.cfg
@@ -182,7 +182,7 @@ sidemenu_item_download_czop="Ke&nbsp;stažení"
 
 http_zobraz_adr_hu="zsolozsma.katolikus.hu"
 mail_adresa_hu="videky-hu@breviar.sk"
-http_bible_references_hu="http://www.szentiras.hu/SZIT/"
+http_bible_references_hu="https://www.szentiras.eu/SZIT/"
 bible_com_version_id_hu="198"
 
 # OPT0

--- a/cgi-bin/breviar-web.cfg
+++ b/cgi-bin/breviar-web.cfg
@@ -201,7 +201,7 @@ sidemenu_item_download_czop="Ke&nbsp;stažení"
 http_adresa_hu="/hu/"
 http_zobraz_adr_hu="zsolozsma.katolikus.hu"
 mail_adresa_hu="videky-hu@breviar.sk"
-http_bible_references_hu="http://www.szentiras.hu/SZIT/"
+http_bible_references_hu="https://www.szentiras.eu/SZIT/"
 bible_com_version_id_hu="198"
 
 # OPT0

--- a/source/bible.h
+++ b/source/bible.h
@@ -268,7 +268,7 @@ const char* bible_references_default[POCET_JAZYKOV + 1] =
 	"http://www.vatican.va/archive/bible/nova_vulgata/documents/",
 	"",
 	"",
-	"http://www.szentiras.hu/SZIT/",
+	"https://www.szentiras.eu/SZIT/",
 	"",
 	"",
 	"",


### PR DESCRIPTION
The conception of szentiras.hu is changed. Szentiras.eu is the new domain of the old project coordinated by László Elek SJ @borazslo - with same conception. It has all necessary permissions from the church and bible publishers.